### PR TITLE
Add more input configurations

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -260,7 +260,14 @@ void CConfigManager::parseLine(std::string& line) {
     if (line.find(" {") != std::string::npos) {
         auto cat = line.substr(0, line.find(" {"));
         transform(cat.begin(), cat.end(), cat.begin(), ::tolower);
-        currentCategory = cat;
+        if (currentCategory.length() != 0) {
+            currentCategory.push_back(':');
+            currentCategory.append(cat);
+        }
+        else {
+            currentCategory = cat;
+        }
+
         return;
     }
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -55,6 +55,9 @@ void CConfigManager::setDefaultVars() {
     configValues["input:kb_options"].strValue = "";
     configValues["input:kb_rules"].strValue = "";
     configValues["input:kb_model"].strValue = "";
+    configValues["input:repeat_rate"].intValue = 25;
+    configValues["input:repeat_delay"].intValue = 600;
+    configValues["input:touchpad:disable_while_typing"].intValue = 1;
 
     configValues["input:follow_mouse"].intValue = 1;
 

--- a/src/config/defaultConfig.hpp
+++ b/src/config/defaultConfig.hpp
@@ -19,6 +19,12 @@ input {
     kb_model=
     kb_options=
     kb_rules=
+    repeat_rate=
+    repeat_delay=
+
+    touchpad {
+        disable_while_typing=
+    }
 }
 
 general {

--- a/src/managers/InputManager.cpp
+++ b/src/managers/InputManager.cpp
@@ -271,6 +271,11 @@ void CInputManager::newMouse(wlr_input_device* mouse) {
 
         if (libinput_device_config_scroll_has_natural_scroll(LIBINPUTDEV))
             libinput_device_config_scroll_set_natural_scroll_enabled(LIBINPUTDEV, 0 /* Natural */);
+        
+        if (libinput_device_config_dwt_is_available(LIBINPUTDEV)) {
+            const auto DWT = static_cast<enum libinput_config_dwt_state>(g_pConfigManager->getInt("input:touchpad:disable_while_typing") != 0);
+            libinput_device_config_dwt_set_enabled(LIBINPUTDEV, DWT);
+        }
     }
 
     wlr_cursor_attach_input_device(g_pCompositor->m_sWLRCursor, mouse);

--- a/src/managers/InputManager.cpp
+++ b/src/managers/InputManager.cpp
@@ -206,10 +206,13 @@ void CInputManager::newKeyboard(wlr_input_device* keyboard) {
     const auto CONTEXT = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     const auto KEYMAP = xkb_keymap_new_from_names(CONTEXT, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
 
+    const auto REPEATRATE = g_pConfigManager->getInt("input:repeat_rate");
+    const auto REPEATDELAY = g_pConfigManager->getInt("input:repeat_delay");
+
     wlr_keyboard_set_keymap(keyboard->keyboard, KEYMAP);
     xkb_keymap_unref(KEYMAP);
     xkb_context_unref(CONTEXT);
-    wlr_keyboard_set_repeat_info(keyboard->keyboard, 25, 600);
+    wlr_keyboard_set_repeat_info(keyboard->keyboard, REPEATRATE, REPEATDELAY);
 
     PNEWKEYBOARD->hyprListener_keyboardMod.initCallback(&keyboard->keyboard->events.modifiers, &Events::listener_keyboardMod, PNEWKEYBOARD, "Keyboard");
     PNEWKEYBOARD->hyprListener_keyboardKey.initCallback(&keyboard->keyboard->events.key, &Events::listener_keyboardKey, PNEWKEYBOARD, "Keyboard");

--- a/src/managers/InputManager.cpp
+++ b/src/managers/InputManager.cpp
@@ -212,7 +212,7 @@ void CInputManager::newKeyboard(wlr_input_device* keyboard) {
     wlr_keyboard_set_keymap(keyboard->keyboard, KEYMAP);
     xkb_keymap_unref(KEYMAP);
     xkb_context_unref(CONTEXT);
-    wlr_keyboard_set_repeat_info(keyboard->keyboard, REPEATRATE, REPEATDELAY);
+    wlr_keyboard_set_repeat_info(keyboard->keyboard, std::max(0, REPEATRATE), std::max(0, REPEATDELAY));
 
     PNEWKEYBOARD->hyprListener_keyboardMod.initCallback(&keyboard->keyboard->events.modifiers, &Events::listener_keyboardMod, PNEWKEYBOARD, "Keyboard");
     PNEWKEYBOARD->hyprListener_keyboardKey.initCallback(&keyboard->keyboard->events.key, &Events::listener_keyboardKey, PNEWKEYBOARD, "Keyboard");


### PR DESCRIPTION
Introduce new input configuration: input_rate, input_delay and disable_while_while_typing. It also makes possible to create subcategories in the configuration (03624e206009e5c1c14a2ad48e37865ec7741e00), so `touchpad { }` section can exist within `input { }`.

As far as I can tell, this doesn't introduce new bugs. The wiki must be updated to include the new changes.
