### PR TITLE
Hyprctrl: Use printf format specifiers for the usage string

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
     int bflag = 0, sflag = 0, index, c;
 
     if (argc < 2) {
-        printf(USAGE.c_str());
+        printf("%s", USAGE.c_str());
         return 1;
     }
 
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
     else if (!strcmp(argv[1], "keyword")) keywordRequest(argc, argv);
     else if (!strcmp(argv[1], "--batch")) batchRequest(argc, argv);
     else {
-        printf(USAGE.c_str());
+        printf("%s", USAGE.c_str());
         return 1;
     }
 


### PR DESCRIPTION
# Describe your PR, what does it fix/add?

Adds format specifiers to `printf` in Hyprctl, otherwise Hyprland doesn't compile on my system due to `-Werror=format-security`:

```bash
./main.cpp:135:15: error: format not a string literal and no format arguments [-Werror=format-security]
  135 |         printf(USAGE.c_str());
```

It's good practice to always include format specifiers anyways, even though this does not revolve around user input

# Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

# Is it ready for merging, or does it need work?

Yes
