### PR TITLE
Opacity setting for fullscreen windows

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -42,6 +42,7 @@ void CConfigManager::setDefaultVars() {
     configValues["decoration:blur_passes"].intValue = 1;
     configValues["decoration:active_opacity"].floatValue = 1;
     configValues["decoration:inactive_opacity"].floatValue = 1;
+    configValues["decoration:fullscreen_opacity"].floatValue = 1;
 
     configValues["dwindle:pseudotile"].intValue = 0;
     configValues["dwindle:col.group_border"].intValue = 0x66777700;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -97,7 +97,8 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, SMonitor* pMonitor, timespec*
     renderdata.h = pWindow->m_vRealSize.vec().y;
     renderdata.dontRound = pWindow->m_bIsFullscreen;
     renderdata.fadeAlpha = pWindow->m_fAlpha.fl() * (PWORKSPACE->m_fAlpha.fl() / 255.f);
-    renderdata.alpha = pWindow == g_pCompositor->m_pLastWindow ? g_pConfigManager->getFloat("decoration:active_opacity") : g_pConfigManager->getFloat("decoration:inactive_opacity");
+    renderdata.alpha = pWindow->m_bIsFullscreen ? g_pConfigManager->getFloat("decoration:fullscreen_opacity") :
+        pWindow == g_pCompositor->m_pLastWindow ? g_pConfigManager->getFloat("decoration:active_opacity") : g_pConfigManager->getFloat("decoration:inactive_opacity");
 
     // apply window special data
     renderdata.alpha *= pWindow->m_sSpecialRenderData.alpha;


### PR DESCRIPTION
A very simple pull request that adds a third opacity setting specifically for fullscreen windows. By default it's set to 1 since I'm assuming that's what most people would use it for, but I added it to the config options too cause why not.

Full disclosure, I have zero experience with C++ so I just copied what I'm assuming would be good style.