### PR TITLE
Nix: more tweaks to the flake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,19 +44,3 @@ jobs:
       - name: Build Hyprland with LEGACY_RENDERER
         run: |
           make legacyrenderer
-
-  nix:
-    name: "Build Hyprland (Nix)"
-    runs-on: ubuntu-latest
-    steps:
-    - name: Clone repository
-      uses: actions/checkout@v3
-    - name: Install nix
-      uses: cachix/install-nix-action@v17
-      with:
-        install_url: https://releases.nixos.org/nix/nix-2.8.0/install
-        extra_nix_config: |
-          auto-optimise-store = true
-          experimental-features = nix-command flakes
-    - name: Build HyprLand with default settings
-      run: nix build --print-build-logs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Fix permissions for git
         run: |
           git config --global --add safe.directory /__w/Hyprland/Hyprland
-        
+
       - name: Checkout Hyprland
         uses: actions/checkout@v3
 
@@ -45,3 +45,18 @@ jobs:
         run: |
           make legacyrenderer
 
+  nix:
+    name: "Build Hyprland (Nix)"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v3
+    - name: Install nix
+      uses: cachix/install-nix-action@v17
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.8.0/install
+        extra_nix_config: |
+          auto-optimise-store = true
+          experimental-features = nix-command flakes
+    - name: Build HyprLand with default settings
+      run: nix build --print-build-logs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Build Hyprland
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   gcc:
     name: "Build Hyprland (Arch)"

--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -1,0 +1,19 @@
+name: Build Hyprland (Nix)
+
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  nix:
+    name: "Build Hyprland (Nix)"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v3
+    - name: Install nix
+      uses: cachix/install-nix-action@v17
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.8.0/install
+        extra_nix_config: |
+          auto-optimise-store = true
+          experimental-features = nix-command flakes
+    - name: Build HyprLand with default settings
+      run: nix build --print-build-logs

--- a/default.nix
+++ b/default.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation {
     install -Dm755 ./build/Hyprland -t $out/bin
     install -Dm755 ./hyprctl/hyprctl -t $out/bin
     install -Dm644 ./assets/* -t $out/share/hyprland
+    install -Dm644 ./example/hyprland.conf -t $out/share/hyprland
     popd
   '';
 

--- a/default.nix
+++ b/default.nix
@@ -1,30 +1,55 @@
-{ lib, stdenv, fetchFromGitHub, src, pkg-config, cmake, ninja, libdrm, libinput
-, libxcb, libxkbcommon, mesa, mount, pango, wayland, wayland-protocols
-, wayland-scanner, wlroots, xcbutilwm, xwayland, enableXWayland ? true }:
-
-stdenv.mkDerivation rec {
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  ninja,
+  libdrm,
+  libinput,
+  libxcb,
+  libxkbcommon,
+  mesa,
+  mount,
+  pango,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  wlroots,
+  xcbutilwm,
+  xwayland,
+  enableXWayland ? true,
+  version ? "git",
+}:
+stdenv.mkDerivation {
   pname = "hyprland";
-  version = "git";
-  inherit src;
+  inherit version;
+  src = ./.;
 
-  nativeBuildInputs = [ cmake ninja pkg-config wayland ]
-    ++ lib.optional enableXWayland xwayland;
-
-  buildInputs = [
-    libdrm
-    libinput
-    libxcb
-    libxkbcommon
-    mesa
-    pango
-    wayland-protocols
-    wayland-scanner
-    wlroots
-    (wlroots.override { inherit enableXWayland; })
-    xcbutilwm
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
   ];
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ]
+  buildInputs =
+    [
+      libdrm
+      libinput
+      libxcb
+      libxkbcommon
+      mesa
+      pango
+      wayland
+      wayland-protocols
+      wayland-scanner
+      (wlroots.override {inherit enableXWayland;})
+      xcbutilwm
+    ]
+    ++ lib.optional enableXWayland xwayland;
+
+  cmakeFlags =
+    ["-DCMAKE_BUILD_TYPE=Release"]
     ++ lib.optional (!enableXWayland) "-DNO_XWAYLAND=true";
 
   prePatch = ''
@@ -38,25 +63,21 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    cd ../
-    mkdir -p $out/share/wayland-sessions
-    cp ./example/hyprland.desktop $out/share/wayland-sessions
-    mkdir -p $out/bin
-    cp ./build/Hyprland $out/bin
-    cp ./hyprctl/hyprctl $out/bin
-    mkdir -p $out/share/hyprland
-    cp ./assets/wall_2K.png $out/share/hyprland
-    cp ./assets/wall_4K.png $out/share/hyprland
-    cp ./assets/wall_8K.png $out/share/hyprland
+    pushd ..
+    install -Dm644 ./example/hyprland.desktop -t $out/share/wayland-sessions
+    install -Dm755 ./build/Hyprland -t $out/bin
+    install -Dm755 ./hyprctl/hyprctl -t $out/bin
+    install -Dm644 ./assets/* -t $out/share/hyprland
+    popd
   '';
 
-  passthru.providedSessions = [ "hyprland" ];
+  passthru.providedSessions = ["hyprland"];
 
   meta = with lib; {
     homepage = "https://github.com/vaxerski/Hyprland";
-    description =
-      "A dynamic tiling Wayland compositor that doesn't sacrifice on its looks";
+    description = "A dynamic tiling Wayland compositor that doesn't sacrifice on its looks";
     license = licenses.bsd3;
     platforms = platforms.linux;
+    mainProgram = "Hyprland";
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,71 +1,5 @@
 {
   "nodes": {
-    "cachix": {
-      "locked": {
-        "lastModified": 1652530570,
-        "narHash": "sha256-GWRrbUv9l1GSyBkj39s9AqNLX1l3rzVOwvnuG4WYM+E=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "4c560cc7ee57e1fb28e6fd7bdacdf01f948f8a91",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-21.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1652557277,
-        "narHash": "sha256-jSes9DaIVMdmwBB78KkFUVrlDzawmD62vrUg0GS2500=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "12806d31a381e7cd169a6bac35590e7b36dc5fe5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "lib-aggregate": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1652616584,
-        "narHash": "sha256-9Uc/k/t08QsJ8rl1n/cbT8L/JrCoDuE7TmsE+F1OiS8=",
-        "owner": "nix-community",
-        "repo": "lib-aggregate",
-        "rev": "81165c2e94b56afcb9486b82dc91d92dfb503a6b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "lib-aggregate",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1652659998,
@@ -77,58 +11,6 @@
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1652576347,
-        "narHash": "sha256-52Wu7hkcIRcS4UenSSrt01J2sAbbQ6YqxZIDpuEPL/c=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "bdf553800c9c34ed00641785b02038f67f44d671",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-wayland": {
-      "inputs": {
-        "cachix": "cachix",
-        "flake-compat": "flake-compat",
-        "lib-aggregate": "lib-aggregate",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1652618007,
-        "narHash": "sha256-eOH21ElHKORg1kd8Z/qX9naZElAOpCt5fPq26AxMQSw=",
-        "owner": "nix-community",
-        "repo": "nixpkgs-wayland",
-        "rev": "4588213f577661d37a42c7b6bba04c138c02d78f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs-wayland",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1652467128,
-        "narHash": "sha256-1wuQ7QgPQ3tugYcoVMJ3pUzl4wVdBzKZr9qtJAgA4VI=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "fb222e008681fce4608e94f2d1dfdf3d03a364c4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -137,27 +19,10 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "nixpkgs-wayland": "nixpkgs-wayland",
-        "utils": "utils",
-        "wlroots-git": "wlroots-git"
+        "wlroots": "wlroots"
       }
     },
-    "utils": {
-      "locked": {
-        "lastModified": 1652557277,
-        "narHash": "sha256-jSes9DaIVMdmwBB78KkFUVrlDzawmD62vrUg0GS2500=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "12806d31a381e7cd169a6bac35590e7b36dc5fe5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "wlroots-git": {
+    "wlroots": {
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",

--- a/flake.nix
+++ b/flake.nix
@@ -1,43 +1,34 @@
-# Based on fortuneteller2k's (https://github.com/fortuneteller2k/nixpkgs-f2k) package repo
 {
-  description =
-    "Hyprland is a dynamic tiling Wayland compositor that doesn't sacrifice on its looks.";
+  description = "Hyprland is a dynamic tiling Wayland compositor that doesn't sacrifice on its looks";
+
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
-    utils.url = "github:numtide/flake-utils";
-    nixpkgs-wayland.url = "github:nix-community/nixpkgs-wayland";
-    wlroots-git = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    wlroots = {
       url = "gitlab:wlroots/wlroots?host=gitlab.freedesktop.org";
       flake = false;
     };
   };
 
-  outputs = { self, nixpkgs, utils, nixpkgs-wayland, wlroots-git }:
-    {
-      overlay = final: prev: {
-        hyprland = prev.callPackage self {
-          src = self;
-          wlroots = (nixpkgs-wayland.overlays.default final prev).wlroots.overrideAttrs (prev: rec {
-            src = wlroots-git;
-          });
-        };
-      };
-      overlays.default = self.overlay;
-    } // utils.lib.eachSystem [ "aarch64-linux" "x86_64-linux" ] (system:
-      let pkgs = nixpkgs.legacyPackages.${system};
-      in rec {
-        packages = {
-          hyprland = pkgs.callPackage self {
-            src = self;
-            wlroots = nixpkgs-wayland.packages.${system}.wlroots.overrideAttrs (prev: rec {
-            src = wlroots-git;
-          });
-          };
-        };
-        defaultPackage = packages.hyprland;
-        apps.hyprland = utils.lib.mkApp { drv = packages.hyprland; };
-        defaultApp = apps.hyprland;
-        apps.default =
-          utils.lib.mkApp { drv = self.packages.${system}.hyprland; };
+  outputs = inputs @ {
+    self,
+    nixpkgs,
+    ...
+  }: let
+    supportedSystems = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    genSystems = nixpkgs.lib.genAttrs supportedSystems;
+    pkgsFor = nixpkgs.legacyPackages;
+  in {
+    packages = genSystems (system: {
+      wlroots = pkgsFor.${system}.wlroots.overrideAttrs (prev: {
+        src = inputs.wlroots;
       });
+      default = pkgsFor.${system}.callPackage ./default.nix {
+        version = self.lastModifiedDate;
+        inherit (self.packages.${system}) wlroots;
+      };
+    });
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
   in {
     packages = genSystems (system: {
       wlroots = pkgsFor.${system}.wlroots.overrideAttrs (prev: {
+        version = inputs.wlroots.lastModifiedDate;
         src = inputs.wlroots;
       });
       default = pkgsFor.${system}.callPackage ./default.nix {
@@ -30,5 +31,8 @@
         inherit (self.packages.${system}) wlroots;
       };
     });
+    formatter = genSystems (system: pkgsFor.${system}.alejandra);
+    # TODO Provide a nixos module for easy installation
+    # nixosModules.default = import ./module.nix;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,15 @@
         inherit (self.packages.${system}) wlroots;
       };
     });
+
     formatter = genSystems (system: pkgsFor.${system}.alejandra);
-    # TODO Provide a nixos module for easy installation
+
+    # TODO Provide a nixos module for easy installation and configuration
     # nixosModules.default = import ./module.nix;
+
+    # Deprecated
+    overlay = _: prev: {
+      hyprland = self.packages.${prev.system}.default;
+    };
   };
 }

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,62 @@
+# Copied from https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/sway.nix
+self: {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.programs.hyprland;
+in {
+  options.programs.hyprland = {
+    enable = mkEnableOption ''
+      Hyprland, the dynamic tiling Wayland compositor that doesn't sacrifice on its looks.
+      You can manually launch Hyprland by executing "exec Hyprland" on a TTY.
+      A configuration file will be generated in ~/.config/hypr/hyprland.conf.
+      See <link xlink:href="https://github.com/vaxerski/Hyprland/wiki" /> for
+      more information.
+    '';
+
+    package = mkOption {
+      type = types.package;
+      default = self.packages.${pkgs.system}.default;
+      defaultText = literalExpression "<Hyprland flake>.packages.<system>.default";
+      example = literalExpression "<Hyprland flake>.packages.<system>.default.override { }";
+      description = ''
+        Hyprland package to use.
+      '';
+    };
+
+    extraPackages = mkOption {
+      type = with types; listOf package;
+      default = with pkgs; [
+        kitty
+        wofi
+        swaybg
+      ];
+      defaultText = literalExpression ''
+        with pkgs; [ kitty wofi swaybg ];
+      '';
+      example = literalExpression ''
+        with pkgs; [
+          alacritty wofi
+        ]
+      '';
+      description = ''
+        Extra packages to be installed system wide.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [cfg.package] ++ cfg.extraPackages;
+    security.polkit.enable = true;
+    hardware.opengl.enable = mkDefault true;
+    fonts.enableDefaultFonts = mkDefault true;
+    programs.dconf.enable = mkDefault true;
+    services.xserver.displayManager.sessionPackages = [cfg.package];
+    programs.xwayland.enable = mkDefault true;
+    xdg.portal.enable = mkDefault true;
+    xdg.portal.extraPortals = [pkgs.xdg-desktop-portal-wlr];
+  };
+}


### PR DESCRIPTION
Hello, I made some changes to the flake.nix to further comply with the ecosystem.
Before anything, I want to discuss it with the previous contributors of the flake (pinging @Narice @Tanish2002  #78 )
- `packages`: changed the output to `default`, which is the new default target instead of `#defaultPackage.<system>`. I also added an output for the custom wlroots build, in case some builds fail in the future.
- `apps`: the latest versions of nix automatically convert `packages` to `apps` by using the attribute `meta.mainProgram`, and it picks up `packages.<system>.default` or `apps.<system>.default`. So this output is not needed anymore.
- `inputs`: I removed FU (bloat). `nixpkgs-wayland`'s wlroots was just `nixpkgs`'s wlroots with an overriden `src`, which is exactly what we do in `packages.<system>.wlroots`, so I removed it too. The `nixpkgs` input has been changed to `nixos-unstable`, which I find more reasonable, given the nature of the software.
- `formatters`: a recently added output, which formats all nix files just by running `nix fmt`. I chose `alejandra` as the formatter (and formatted all the nixfiles with it), as I find that it produces the most diff-friendly code. Open to discussion...
- `overlay`: initially I wanted to entirely remove this output, but decided to keep it to not break people's setups. With such a simple flake layout, the downstream consumers can just use `(inputs).Hyprland.packages.x86_64-linux.default`, instead of adding the overlay, and then `pkgs.hyprland`. Overlays are cumbersome to use, compose, and introduce some other problems (read https://zimbatm.com/notes/1000-instances-of-nixpkgs ).

Following this, the wiki should be updated to include information for installation without overlays.

I also added a GitHub Workflow that automatically builds the package, in parallel with the Arch build. You can see it in action here: https://github.com/viperML/Hyprland/actions/runs/2338469084 . Ideally, another GH action would be needed to bump the `flake.lock` on schedule (weekly maybe?)