### PR TITLE
nix: update workflow and bump flake

### DIFF
--- a/.github/workflows/nix-update.yaml
+++ b/.github/workflows/nix-update.yaml
@@ -1,0 +1,25 @@
+name: "Nix: update lockfile"
+
+on:
+  schedule:
+    - cron: '0 0 */14 * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v3
+    - name: Install nix
+      uses: cachix/install-nix-action@v17
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.8.0/install
+        extra_nix_config: |
+          auto-optimise-store = true
+          experimental-features = nix-command flakes
+    - name: Update lockfile
+      run: nix flake update
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: "[gha] bump flake inputs"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652659998,
-        "narHash": "sha256-FqNrXC1EE6U2RACwXBlsAvg1lqQGLYpuYb6+W3DL9vA=",
+        "lastModified": 1653407748,
+        "narHash": "sha256-g9puJaILRTb9ttlLQ7IehpV7Wcy0n+vs8LOFu6ylQcM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d7db1b9e4cf1ee075a9f52e5c36f7b9f4207502",
+        "rev": "5ce6597eca7d7b518c03ecda57d45f9404b5e060",
         "type": "github"
       },
       "original": {
@@ -26,11 +26,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1652629480,
-        "narHash": "sha256-4mouFPYB2VwgPi92trvAk8JAGjvkYm+DX72sUzljCXA=",
+        "lastModified": 1653502661,
+        "narHash": "sha256-unQ1j3jleghIMi340dJTJZZ1ffwm1cI7gaQbdKd7laE=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "8fe3aa29da56be16faa73aca947647bd60cd4a94",
+        "rev": "1cb6b2cf673a5b580d7ad79ce2b37c14b14b0268",
         "type": "gitlab"
       },
       "original": {


### PR DESCRIPTION
Addresses the conversation in #86 

This PR adds an flake update action, so the `flake.lock` is not left for days without update.
This action can be manually triggered to update the dependencies (and the wlroots build) to their latest versions.

The timer is set to run every 2 weeks, which seems reasonable.