### PR TITLE
Fix error: attribute 'lastModifiedDate' missing

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,11 +33,11 @@
   in {
     packages = genSystems (system: {
       wlroots = pkgsFor.${system}.wlroots.overrideAttrs (prev: {
-        version = mkVersion inputs.wlroots.lastModifiedDate;
+        version = mkVersion (toString (inputs.wlroots.lastModifiedDate or inputs.wlroots.lastModified or "19700101"));
         src = inputs.wlroots;
       });
       default = pkgsFor.${system}.callPackage ./nix/default.nix {
-        version = mkVersion self.lastModifiedDate;
+        version = mkVersion (toString (self.lastModifiedDate or self.lastModified or "19700101"));
         inherit (self.packages.${system}) wlroots;
       };
     });


### PR DESCRIPTION
The above error appears on NixOS 22.05 when using the flake. It appears that lastModifiedDate has been renamed to lastModified, although I can't find a version at which this change happened:
https://github.com/NixOS/templates/issues/13

This fix only applies to some versions of flakes, on the previous versions the old behaviour is preserved. I've tested on nix 2.8.1.