### PR TITLE
AUR go brrr

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -2,9 +2,9 @@
 
 _pkgname="hyprland"
 pkgname="${_pkgname}"
-pkgver="0.3.0beta"
+pkgver="0.4.0beta"
 pkgrel=2
-pkgdesc="Hyprland is a dynamic tiling Wayland compositor based on wlroots that doesn't sacrifice on its looks."
+pkgdesc="A dynamic tiling Wayland compositor based on wlroots that doesn't sacrifice on its looks."
 arch=(any)
 url="https://github.com/vaxerski/Hyprland"
 license=('BSD')
@@ -48,8 +48,9 @@ makedepends=(
 	wayland-protocols
 	xorgproto)
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/vaxerski/hyprland/archive/v${pkgver}.tar.gz")
-sha256sums=('46ba9b61570f3385673dfd27a3d1dc5a084236f138bca1c2537335e0cdce9e78')
-conflicts=("${_pkgname}-git" "${_pkgname}" "${_pkgname}-bin")
+sha256sums=('5969e5f88426f90acdfb5958644733d8a9409389c2d345514c58a66cf74d2f91')
+conflicts=("${_pkgname}")
+provides=(hyprland)
 options=(!makeflags !buildflags)
 
 build() {

--- a/aur/PKGBUILD-bin
+++ b/aur/PKGBUILD-bin
@@ -2,9 +2,9 @@
 
 _pkgname="hyprland"
 pkgname="${_pkgname}-bin"
-pkgver="0.3.0beta"
+pkgver="0.4.0beta"
 pkgrel=2
-pkgdesc="Hyprland is a dynamic tiling Wayland compositor based on wlroots that doesn't sacrifice on its looks."
+pkgdesc="A dynamic tiling Wayland compositor based on wlroots that doesn't sacrifice on its looks."
 arch=(any)
 url="https://github.com/vaxerski/Hyprland"
 license=('BSD')
@@ -38,8 +38,9 @@ depends=(
 	vulkan-validation-layers
 	xorg-xwayland)
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/vaxerski/Hyprland/releases/download/v${pkgver}/v${pkgver}.tar.gz")
-sha256sums=('46ba9b61570f3385673dfd27a3d1dc5a084236f138bca1c2537335e0cdce9e78')
-conflicts=("${_pkgname}-git" "${_pkgname}" "${_pkgname}-bin")
+sha256sums=('5969e5f88426f90acdfb5958644733d8a9409389c2d345514c58a66cf74d2f91')
+conflicts=("${_pkgname}")
+provides=(hyprland)
 
 package() {
 	cd "$srcdir/Hyprland-$pkgver"

--- a/aur/PKGBUILD-git
+++ b/aur/PKGBUILD-git
@@ -2,9 +2,9 @@
 
 _pkgname="hyprland"
 pkgname="${_pkgname}-git"
-pkgver=r655.gef85544
-pkgrel=1
-pkgdesc="Hyprland is a dynamic tiling Wayland compositor based on wlroots that doesn't sacrifice on its looks."
+pkgver=r673.gb62e530
+pkgrel=2
+pkgdesc="A dynamic tiling Wayland compositor based on wlroots that doesn't sacrifice on its looks."
 arch=(any)
 url="https://github.com/vaxerski/Hyprland"
 license=('BSD')
@@ -48,7 +48,8 @@ makedepends=(
 	wayland-protocols
 	xorgproto)
 source=("${_pkgname}::git+https://github.com/vaxerski/Hyprland.git")
-conflicts=("${_pkgname}-git" "${_pkgname}" "${_pkgname}-bin")
+conflicts=("${_pkgname}")
+provides=(hyprland)
 sha256sums=('SKIP')
 options=(!makeflags !buildflags)
 

--- a/aur/PKGBUILD-git
+++ b/aur/PKGBUILD-git
@@ -1,8 +1,8 @@
-# Maintainer: ThatOneCalculator <kainoa@t1c.dev>, Sander van Kasteel <info@sandervankasteel.nl>
+# Maintainer: ThatOneCalculator <kainoa@t1c.dev>
 
 _pkgname="hyprland"
-pkgname="${_pkgname}-git"
-pkgver=r673.gb62e530
+pkgname="${_pkgname}-bin"
+pkgver="0.4.0beta"
 pkgrel=2
 pkgdesc="A dynamic tiling Wayland compositor based on wlroots that doesn't sacrifice on its looks."
 arch=(any)
@@ -37,42 +37,18 @@ depends=(
 	vulkan-icd-loader
 	vulkan-validation-layers
 	xorg-xwayland)
-makedepends=(
-	git
-	cmake
-	ninja
-	gcc
-	gdb
-	meson
-	vulkan-headers
-	wayland-protocols
-	xorgproto)
-source=("${_pkgname}::git+https://github.com/vaxerski/Hyprland.git")
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/vaxerski/Hyprland/releases/download/v${pkgver}/v${pkgver}.tar.gz")
+sha256sums=('5969e5f88426f90acdfb5958644733d8a9409389c2d345514c58a66cf74d2f91')
 conflicts=("${_pkgname}")
 provides=(hyprland)
-sha256sums=('SKIP')
-options=(!makeflags !buildflags)
-
-pkgver() {
-  cd "$_pkgname"
-  ( set -o pipefail
-    git describe --long 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
-    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
-  )
-}
-
-build() {
-	cd "${srcdir}/${_pkgname}"
-	git submodule update --init
-	make all
-}
 
 package() {
-	cd "${srcdir}/${_pkgname}"
+	cd "$srcdir/Hyprland-$pkgver"
 	mkdir -p "${pkgdir}/usr/share/wayland-sessions"
 	mkdir -p "${pkgdir}/usr/share/hyprland"
-	install -Dm755 build/Hyprland -t "${pkgdir}/usr/bin"
-	install -Dm755 hyprctl/hyprctl -t "${pkgdir}/usr/bin"
+	install -Dm755 ./Hyprland -t "${pkgdir}/usr/bin"
+	install -Dm755 ./hyprctl -t "${pkgdir}/usr/bin"
+	install -Dm755 ./libwlroots.so.11032 -t "${pkgdir}/usr/lib"
 	install -Dm644 assets/*.png -t "${pkgdir}/usr/share/hyprland"
 	install -Dm644 example/hyprland.desktop -t "${pkgdir}/usr/share/wayland-sessions"
 	install -Dm644 example/hyprland.conf -t "${pkgdir}/usr/share/hyprland"

--- a/aur/PKGBUILD-git
+++ b/aur/PKGBUILD-git
@@ -1,8 +1,8 @@
-# Maintainer: ThatOneCalculator <kainoa@t1c.dev>
+# Maintainer: ThatOneCalculator <kainoa@t1c.dev>, Sander van Kasteel <info@sandervankasteel.nl>
 
 _pkgname="hyprland"
-pkgname="${_pkgname}-bin"
-pkgver="0.4.0beta"
+pkgname="${_pkgname}-git"
+pkgver=r673.gb62e530
 pkgrel=2
 pkgdesc="A dynamic tiling Wayland compositor based on wlroots that doesn't sacrifice on its looks."
 arch=(any)
@@ -37,18 +37,42 @@ depends=(
 	vulkan-icd-loader
 	vulkan-validation-layers
 	xorg-xwayland)
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/vaxerski/Hyprland/releases/download/v${pkgver}/v${pkgver}.tar.gz")
-sha256sums=('5969e5f88426f90acdfb5958644733d8a9409389c2d345514c58a66cf74d2f91')
+makedepends=(
+	git
+	cmake
+	ninja
+	gcc
+	gdb
+	meson
+	vulkan-headers
+	wayland-protocols
+	xorgproto)
+source=("${_pkgname}::git+https://github.com/vaxerski/Hyprland.git")
 conflicts=("${_pkgname}")
 provides=(hyprland)
+sha256sums=('SKIP')
+options=(!makeflags !buildflags)
+
+pkgver() {
+  cd "$_pkgname"
+  ( set -o pipefail
+    git describe --long 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  )
+}
+
+build() {
+	cd "${srcdir}/${_pkgname}"
+	git submodule update --init
+	make all
+}
 
 package() {
-	cd "$srcdir/Hyprland-$pkgver"
+	cd "${srcdir}/${_pkgname}"
 	mkdir -p "${pkgdir}/usr/share/wayland-sessions"
 	mkdir -p "${pkgdir}/usr/share/hyprland"
-	install -Dm755 ./Hyprland -t "${pkgdir}/usr/bin"
-	install -Dm755 ./hyprctl -t "${pkgdir}/usr/bin"
-	install -Dm755 ./libwlroots.so.11032 -t "${pkgdir}/usr/lib"
+	install -Dm755 build/Hyprland -t "${pkgdir}/usr/bin"
+	install -Dm755 hyprctl/hyprctl -t "${pkgdir}/usr/bin"
 	install -Dm644 assets/*.png -t "${pkgdir}/usr/share/hyprland"
 	install -Dm644 example/hyprland.desktop -t "${pkgdir}/usr/share/wayland-sessions"
 	install -Dm644 example/hyprland.conf -t "${pkgdir}/usr/share/hyprland"


### PR DESCRIPTION
Updates description, uses `provides`

Who knew the AUR had a rule against having the package's name in the description lmao