### PR TITLE
Add natural_scrolling option for touchpads only

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -84,6 +84,7 @@ void CConfigManager::setDefaultVars() {
     configValues["input:natural_scroll"].intValue = 0;
     configValues["input:numlock_by_default"].intValue = 0;
     configValues["input:force_no_accel"].intValue = 0;
+    configValues["input:touchpad:natural_scroll"].intValue = 0;
     configValues["input:touchpad:disable_while_typing"].intValue = 1;
 
     configValues["input:follow_mouse"].intValue = 1;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -326,8 +326,14 @@ void CInputManager::newMouse(wlr_input_device* mouse) {
         if (libinput_device_config_tap_get_finger_count(LIBINPUTDEV))  // this is for tapping (like on a laptop)
             libinput_device_config_tap_set_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_TAP_ENABLED);
 
-        if (libinput_device_config_scroll_has_natural_scroll(LIBINPUTDEV))
-            libinput_device_config_scroll_set_natural_scroll_enabled(LIBINPUTDEV, g_pConfigManager->getInt("input:natural_scroll"));
+        if (libinput_device_config_scroll_has_natural_scroll(LIBINPUTDEV)) {
+            double w = 0, h = 0;
+
+            if (libinput_device_has_capability(LIBINPUTDEV, LIBINPUT_DEVICE_CAP_POINTER) && libinput_device_get_size(LIBINPUTDEV, &w, &h) == 0) // pointer with size is a touchpad
+                libinput_device_config_scroll_set_natural_scroll_enabled(LIBINPUTDEV, g_pConfigManager->getInt("input:touchpad:natural_scroll"));
+            else
+                libinput_device_config_scroll_set_natural_scroll_enabled(LIBINPUTDEV, g_pConfigManager->getInt("input:natural_scroll"));
+        }
         
         if (libinput_device_config_dwt_is_available(LIBINPUTDEV)) {
             const auto DWT = static_cast<enum libinput_config_dwt_state>(g_pConfigManager->getInt("input:touchpad:disable_while_typing") != 0);


### PR DESCRIPTION
This PR makes the existing `input:natural_scroll` setting affect only the mouse, and adds a separate `input:touchpad:natural_scroll` for touchpads.