### PR TITLE
Add loose follow_mouse option

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -167,14 +167,14 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     Vector2D surfaceLocal = surfacePos == Vector2D(-1337, -1337) ? surfaceCoords : mouseCoords - surfacePos;
 
     if (pFoundWindow) {
-        const int FOLLOWMOUSE = g_pConfigManager->getInt("input:follow_mouse");
-        if (FOLLOWMOUSE != 1 && !refocus) {
+        static auto *const PFOLLOWMOUSE = &g_pConfigManager->getConfigValuePtr("input:follow_mouse")->intValue;
+        if (*PFOLLOWMOUSE != 1 && !refocus) {
             if (pFoundWindow != g_pCompositor->m_pLastWindow && g_pCompositor->windowValidMapped(g_pCompositor->m_pLastWindow) && (g_pCompositor->m_pLastWindow->m_bIsFloating != pFoundWindow->m_bIsFloating)) {
                 // enter if change floating style
                 g_pCompositor->focusWindow(pFoundWindow, foundSurface);
                 wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
             }
-            else if (FOLLOWMOUSE == 2) {
+            else if (*PFOLLOWMOUSE == 2) {
                 wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
             }
             wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, time, surfaceLocal.x, surfaceLocal.y);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -167,10 +167,14 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     Vector2D surfaceLocal = surfacePos == Vector2D(-1337, -1337) ? surfaceCoords : mouseCoords - surfacePos;
 
     if (pFoundWindow) {
-        if (g_pConfigManager->getInt("input:follow_mouse") == 0 && !refocus) {
+        const int FOLLOWMOUSE = g_pConfigManager->getInt("input:follow_mouse");
+        if (FOLLOWMOUSE != 1 && !refocus) {
             if (pFoundWindow != g_pCompositor->m_pLastWindow && g_pCompositor->windowValidMapped(g_pCompositor->m_pLastWindow) && (g_pCompositor->m_pLastWindow->m_bIsFloating != pFoundWindow->m_bIsFloating)) {
                 // enter if change floating style
                 g_pCompositor->focusWindow(pFoundWindow, foundSurface);
+                wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
+            }
+            else if (FOLLOWMOUSE == 2) {
                 wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
             }
             wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, time, surfaceLocal.x, surfaceLocal.y);


### PR DESCRIPTION
Allows the `follow_mouse` config option to be set to 2, which makes it so that moving the cursor doesn't focus windows, but still calls `notify_enter` so that the windows interact with the cursor correctly (such as for scrolling and hover effects). Keyboard events like typing and navigation still occur in the focused window. Tested and works on Arch.