### PR TITLE
Resolves #204. Enables numlock on startup when configured to do so

### DIFF
--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -87,6 +87,7 @@ extern "C" {
 #include "../wlroots/include/wlr/render/wlr_texture.h"
 #include "../wlroots/include/wlr/types/wlr_pointer_constraints_v1.h"
 #include "../wlroots/include/wlr/types/wlr_relative_pointer_v1.h"
+#include "../wlroots/include/wlr/interfaces/wlr_keyboard.h"
 }
 
 #undef class

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -309,7 +309,7 @@ void CInputManager::setKeyboardLayout() {
     }
 
     if (wlrMods.locked != 0) {
-        wlr_seat_keyboard_notify_modifiers(g_pCompositor->m_sSeat.seat, &wlrMods);
+        wlr_keyboard_notify_modifiers(g_pInputManager->m_pActiveKeyboard->keyboard->keyboard, 0, 0, wlrMods.locked, 0);
     }
 
     xkb_keymap_unref(KEYMAP);


### PR DESCRIPTION
Describe your PR, what does it fix/add?
Addresses #204, and makes the numlock enabling work properly.

Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This is the same method that sway uses to accomplish this. I haven't done extensive testing, but it works as expected for me.

Is it ready for merging, or does it need work?
As far as I know it is ready for merging, but if there are issues with it please let me know and I can change it.
