### PR TITLE
newline at execution end

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -136,10 +136,12 @@ int main(int argc, char** argv) {
     else if (!strcmp(argv[1], "dispatch")) dispatchRequest(argc, argv);
     else if (!strcmp(argv[1], "keyword")) keywordRequest(argc, argv);
     else if (!strcmp(argv[1], "--batch")) batchRequest(argc, argv);
+    else if (!strcmp(argv[1], "--help")) {printf("%s", USAGE.c_str()); return 0;}
     else {
         printf("%s", USAGE.c_str());
         return 1;
     }
-
+    
+    printf("\n");
     return 0;
 }


### PR DESCRIPTION
Describe your PR, what does it fix/add?
_hyprctl wasn't printing a newline after printing most output (everything but the help mesage) and using_ `hyprctl --help` _printed a help message (since it didn't recognize the argument) but returned 1_

Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
_I did not test the changes, since they only affect a few, easy, lines and edited them from github.com directly_

Is it ready for merging, or does it need work?
_It should merge without issues_

