### PR TITLE
revised makefile, newline after execution

### DIFF
--- a/hyprctl/Makefile
+++ b/hyprctl/Makefile
@@ -1,4 +1,4 @@
-clean:
-	rm -rf ./hyprctl ./hyprctl
 all:
 	g++ -std=c++20 ./main.cpp -o ./hyprctl
+clean:
+	rm ./hyprctl

--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -134,7 +134,7 @@ int main(int argc, char** argv) {
     else if (!strcmp(argv[1], "dispatch")) dispatchRequest(argc, argv);
     else if (!strcmp(argv[1], "keyword")) keywordRequest(argc, argv);
     else if (!strcmp(argv[1], "--batch")) batchRequest(argc, argv);
-    else if (!strcmp(argv[1], "--help")) printf(USAGE.c_str());
+    else if (!strcmp(argv[1], "--help")) printf("%s", USAGE.c_str());
     else {
         printf("%s\n", USAGE.c_str());
         return 1;

--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -15,8 +15,7 @@
 #include <fstream>
 #include <string>
 
-const std::string USAGE = R"#(
-usage: hyprctl [command] [(opt)args]
+const std::string USAGE = R"#(usage: hyprctl [command] [(opt)args]
     
     monitors
     workspaces
@@ -27,8 +26,7 @@ usage: hyprctl [command] [(opt)args]
     dispatch
     keyword
     version
-    reload
-)#";
+    reload)#";
 
 void request(std::string arg) {
     const auto SERVERSOCKET = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -121,7 +119,7 @@ int main(int argc, char** argv) {
     int bflag = 0, sflag = 0, index, c;
 
     if (argc < 2) {
-        printf("%s", USAGE.c_str());
+        printf("%s\n", USAGE.c_str());
         return 1;
     }
 
@@ -136,10 +134,12 @@ int main(int argc, char** argv) {
     else if (!strcmp(argv[1], "dispatch")) dispatchRequest(argc, argv);
     else if (!strcmp(argv[1], "keyword")) keywordRequest(argc, argv);
     else if (!strcmp(argv[1], "--batch")) batchRequest(argc, argv);
+    else if (!strcmp(argv[1], "--help")) printf(USAGE.c_str());
     else {
-        printf("%s", USAGE.c_str());
+        printf("%s\n", USAGE.c_str());
         return 1;
     }
 
+    printf("\n");
     return 0;
 }


### PR DESCRIPTION
### **Describe your PR, what does it fix/add?**
_The makefile now compiles when just calling_ `make`_, mostly standard, and cleans when using_ `make clean`_. hyprctl now also prints a newline character (0x0a) after running, not just after the help message (which now prints with return code 0 when calling_ `hyprctl --help` _), the old formatting could also cause weird results with some defaults promts_
_old:_
```
[alba4k@ProBook ~]$ hyprctl keyword input:touchpad:natural_scroll 1
Error setting value <1> for field <input:touchpad:natural_scroll>: No such field.[alba4k@ProBook ~]$
```
_new:_
```
[alba4k@ProBook ~]$ hyprctl keyword input:touchpad:natural_scroll 1
Error setting value <1> for field <input:touchpad:natural_scroll>: No such field.
[alba4k@ProBook ~]$
```

### **Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)**
_-_

### **Is it ready for merging, or does it need work?**
_Everything should merge without issues_

