### PR TITLE
Added a multiplier for the width to height ratio

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -53,6 +53,7 @@ void CConfigManager::setDefaultVars() {
     configValues["dwindle:force_split"].intValue = 0;
     configValues["dwindle:preserve_split"].intValue = 0;
     configValues["dwindle:special_scale_factor"].floatValue = 0.8f;
+    configValues["dwindle:split_width_multiplier"].floatValue = 1.0f;
 
     configValues["animations:enabled"].intValue = 1;
     configValues["animations:speed"].floatValue = 7.f;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -23,8 +23,10 @@ void SDwindleNodeData::recalcSizePosRecursive() {
 
         const auto REVERSESPLITRATIO = 2.f - splitRatio;
 
-        if (g_pConfigManager->getInt("dwindle:preserve_split") == 0)
-            splitTop = size.y > size.x;
+        if (g_pConfigManager->getInt("dwindle:preserve_split") == 0) {
+            const auto WIDTHMULTIPLIER = g_pConfigManager->getFloat("dwindle:split_width_multiplier");
+            splitTop = size.y * WIDTHMULTIPLIER > size.x;
+        }
 
         const auto SPLITSIDE = !splitTop;
 


### PR DESCRIPTION
Describe your PR, what does it fix/add?

This resolves my issue here: https://github.com/vaxerski/Hyprland/issues/233

Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I've named the new setting "dwindle:split_width_multiplier" which I think is pretty descriptive, but can be changed.

Is it ready for merging, or does it need work?

Compiles and works
