### PR TITLE
permission-mgr: implement executable path on some BSDs

### DIFF
--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -192,7 +192,7 @@ void NCrashReporter::createAndSaveCrash(int sig) {
 #endif
     };
     u_int  miblen        = sizeof(mib) / sizeof(mib[0]);
-    char   exe[PATH_MAX] = "";
+    char   exe[PATH_MAX] = "/nonexistent";
     size_t sz            = sizeof(exe);
     sysctl(mib, miblen, &exe, &sz, NULL, 0);
     const auto FPATH = std::filesystem::canonical(exe);

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -301,7 +301,7 @@ APICALL std::vector<SFunctionMatch> HyprlandAPI::findFunctionsByName(HANDLE hand
 #endif
     };
     u_int  miblen        = sizeof(mib) / sizeof(mib[0]);
-    char   exe[PATH_MAX] = "";
+    char   exe[PATH_MAX] = "/nonexistent";
     size_t sz            = sizeof(exe);
     sysctl(mib, miblen, &exe, &sz, NULL, 0);
     const auto FPATH = std::filesystem::canonical(exe);


### PR DESCRIPTION
Follow up to https://github.com/hyprwm/Hyprland/pull/9930. Runtime tested only as a snippet due to lack of time.